### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/org/apache/commons/crypto/utils/Utils.java
+++ b/src/main/java/org/apache/commons/crypto/utils/Utils.java
@@ -68,7 +68,7 @@ public final class Utils {
                   }
               }
           } catch (final Exception ex) {
-              System.err.println("Could not load '" + SYSTEM_PROPERTIES_FILE + "' from classpath: " + ex.toString());
+              System.err.println("Could not load '" + SYSTEM_PROPERTIES_FILE + "' from classpath: " + ex);
           }
           return defaultedProps;
       }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-commons-crypto-UnnecessaryToStringCall-265ac4a6467e3e9178bcf812964c35476b978210-sl:71-el:0-sc:106-ec:0-co:2967-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (1)
